### PR TITLE
Fixed charcodes being mangled when replaceing &.

### DIFF
--- a/jquery.autogrow-textarea.js
+++ b/jquery.autogrow-textarea.js
@@ -23,6 +23,7 @@
 		options = $.extend( {
 			vertical: true,
 			horizontal: false,
+            		fixMinHeight: true,
 			characterSlop: 0
 		}, options);
 
@@ -32,7 +33,7 @@
                 minHeight   = $this.height(),
 				maxHeight	= $this.attr( "maxHeight" ),
 				minWidth	= typeof( $this.attr( "minWidth" ) ) == "undefined" ? 0 : $this.attr( "minWidth" );
-            
+            		if( !options.fixMinHeight ) minHeight = 0;
 			if( typeof( maxHeight ) == "undefined" ) maxHeight = 1000000;
 			
             var shadow = $('<div class="autogrow-shadow"></div>').css( {

--- a/jquery.autogrow-textarea.js
+++ b/jquery.autogrow-textarea.js
@@ -61,9 +61,9 @@
 				if( val === '' && $(this).attr("placeholder") ) val = $(this).attr("placeholder");
 				
 				if( options.vertical )
-					val = val.replace(/</g, '&lt;')
+					val = val.replace(/&/g, '&amp;')
+						.replace(/</g, '&lt;')
 						.replace(/>/g, '&gt;')
-						.replace(/&/g, '&amp;')
 						.replace(/\n$/, '<br/>&nbsp;')
 						.replace(/\n/g, '<br/>')
 						.replace(/ {2,}/g, function(space) { return times('&nbsp;', space.length -1) + ' '; });

--- a/jquery.autogrow-textarea.js
+++ b/jquery.autogrow-textarea.js
@@ -32,7 +32,7 @@
             var $this       = $(this),
                 minHeight   = $this.height(),
 				maxHeight	= $this.attr( "maxHeight" ),
-				minWidth	= typeof( $this.attr( "minWidth" ) ) == "undefined" ? 0 : $this.attr( "minWidth" );
+				minWidth	= typeof( $this.attr( "minWidth" ) ) == "undefined" ? 0 : parseInt($this.attr( "minWidth" ), 10);
             		if( !options.fixMinHeight ) minHeight = 0;
 			if( typeof( maxHeight ) == "undefined" ) maxHeight = 1000000;
 			


### PR DESCRIPTION
Doing replace(/&/g, '&amp;') after replace(/&lt;/g, '&amp;lt;') converts all "&amp;lt;" values to "&amp;amp;lt;" this causes display of < and > characters in shadow to be rendered incorrectly and the width miscalculated.