### PR TITLE
fixed charcodes being mangled when replaceing &.

### DIFF
--- a/jquery.autogrow-textarea.js
+++ b/jquery.autogrow-textarea.js
@@ -61,9 +61,9 @@
 				if( val === '' && $(this).attr("placeholder") ) val = $(this).attr("placeholder");
 				
 				if( options.vertical )
-					val = val.replace(/</g, '&lt;')
+					val = val.replace(/&/g, '&amp;')
+						.replace(/</g, '&lt;')
 						.replace(/>/g, '&gt;')
-						.replace(/&/g, '&amp;')
 						.replace(/\n$/, '<br/>&nbsp;')
 						.replace(/\n/g, '<br/>')
 						.replace(/ {2,}/g, function(space) { return times('&nbsp;', space.length -1) + ' '; });


### PR DESCRIPTION
Isolated just the bug fix code:
Doing replace(/&/g, '&amp;') after replace(/&lt;/g, '&amp;lt;') converts all "&amp;lt;" values to "&amp;amp;lt;" this causes display of < and > characters in shadow to be rendered incorrectly and the width miscalculated.
Continued from:
https://github.com/rotundasoftware/jquery.autogrow-textarea/pull/2