### PR TITLE
updates the jquery dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/rotundasoftware/jquery.autogrow-textarea/issues"
   },
   "peerDependencies": {
-    "jquery": "2.x"
+    "jquery": ">=2"
   }
 }


### PR DESCRIPTION
I updated the jQuery peerDependency version to >=2, since 2.x doesn't allow 3.x and it throws warnings during npm install (and also makes shrinkwrap fail).

Tested with jQuery 3.2.1 and seems to work fine.