### PR TITLE
Fix "unable to resolve dependency tree" issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/rotundasoftware/jquery.autogrow-textarea/issues"
   },
   "peerDependencies": {
-    "jquery": "2.x"
+    "jquery": "2.x || 3.x"
   }
 }


### PR DESCRIPTION
Since I upgraded npm to latest version, I have an error everytime I want to execute `npm install` or `npm update`, due to a conflict between the `jquery` version I use and the `jquery` peer dependency declared in your package.

```
$ npm install jquery.autogrow-textarea
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @glpi/glpi@
npm ERR! Found: jquery@3.6.2
npm ERR! node_modules/jquery
npm ERR!   jquery@"^3.4.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer jquery@"2.x" from jquery.autogrow-textarea@0.4.1
npm ERR! node_modules/jquery.autogrow-textarea
npm ERR!   jquery.autogrow-textarea@"^0.4.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

As your plugin is compatible with `jquery` 3.x, the solution is to update the version compatibility on your `package.json` file.